### PR TITLE
Moved the action from the gsd-datatbase to gsd-tools

### DIFF
--- a/actions/deletion-check/action.yml
+++ b/actions/deletion-check/action.yml
@@ -1,0 +1,8 @@
+name: 'Check for deleted files'
+description: 'check for deleted files'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/check.sh
+      shell: bash
+

--- a/actions/deletion-check/check.sh
+++ b/actions/deletion-check/check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+removed_files=$(git diff --name-only --diff-filter=D 'HEAD^' | grep '\.json$' || true)
+
+if [[ -n "$removed_files" ]]; then 
+    echo "::group::removed files"
+        echo "$removed_files"
+    echo "::endgroup::"
+    echo "You shall not change history."
+    exit 1
+fi

--- a/actions/json-check/action.yml
+++ b/actions/json-check/action.yml
@@ -1,0 +1,8 @@
+name: 'Check JSON format'
+description: 'Parse all changed JSON files and fail if one is not valid JSON'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/check.sh
+      shell: bash
+

--- a/actions/json-check/check.sh
+++ b/actions/json-check/check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+git diff --name-only --diff-filter=ACMRT 'HEAD^' |
+    grep '\.json$' |
+    while read -r i; do
+        if ! python -m json.tool "$i" > /dev/null; then
+            echo "Wrong Syntax: $i"
+            exit 1
+        fi
+    done


### PR DESCRIPTION
Moved the script to the gsd-tools repo as suggested by this comment https://github.com/cloudsecurityalliance/gsd-database/pull/2295#issuecomment-1069754624 .

If the PR is accepted the actions can be used as follows

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: '2'
      - name: deletion-check
        uses: cloudsecurityalliance/gsd-tools/actions/deletion-check
      - name: json-check
        uses: cloudsecurityalliance/gsd-tools/actions/json-check
```
See the full example https://github.com/raphaelahrens/gsd-database/blob/action_test/.github/workflows/json.yml

Here an example output from a commit with a broken json file https://github.com/raphaelahrens/gsd-database/runs/5979488733?check_suite_focus=true

Here the output from a deletion https://github.com/raphaelahrens/gsd-database/runs/5971825263?check_suite_focus=true