### PR TITLE
Initial skeleton of Jekyll-based GSD website

### DIFF
--- a/website/.bundle/config
+++ b/website/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,5 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor

--- a/website/404.html
+++ b/website/404.html
@@ -1,0 +1,25 @@
+---
+permalink: /404.html
+layout: default
+---
+
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>404</h1>
+
+  <p><strong>Page not found :(</strong></p>
+  <p>The requested page could not be found.</p>
+</div>

--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.1"
+gem "minima", "~> 2.5"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+#  gem "jekyll-feed", "~> 0.12"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,16 @@
+This is a [Jeyll](https://jekyllrb.com/)-based website for the Global Security Database documentation.
+It is currently in a very initial-state and is based on the default [minima](https://github.com/jekyll/minima) theme.
+The [minima](https://github.com/jekyll/minima) GitHub page has detail on how to customize the theme.
+
+## Getting Started
+
+The `.bundle/config` is configured to install Gems in the local directory rather than on your system.
+You should be able to build and test this site on your own system using the following commands:
+
+```
+bundle install
+bundle exec jekyll serve
+```
+
+This will start a local webserver for you to browse and test you changes.
+

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,0 +1,30 @@
+title: gsd.id
+#email: gsd@groups.cloudsecurityalliance.org
+description: >- # this means to ignore newlines until "baseurl:"
+  The Global Security Database (GSD) is a Working Group project from the Cloud
+  Security Alliance with the goal of building an open source community for
+  improving the quality and usabilty of vulnerability databases.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://gsd.id" # the base hostname & protocol for your site, e.g. http://example.com
+#twitter_username: jekyllrb
+#github_username:  cloudsecurityalliance
+
+# Build settings
+theme: minima
+#plugins:
+#  - jekyll-feed
+
+header_pages:
+  - contribute/index.md
+  - consume/index.md
+  - press.md
+  - about.md
+
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - README.md

--- a/website/about.md
+++ b/website/about.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+The Global Security Database (GSD) is a Working Group project from the [Cloud
+Security Alliance](https://cloudsecurityalliance.org/) with the goal of
+building an open source community for improving the quality and usabilty of
+vulnerability databases.
+
+## Joining
+
+There is a mailing list at
+[https://csaurl.org/list-gsd](https://csaurl.org/list-gsd) for general and
+technical discussion.
+
+The CSA Circle Community is available at 
+[https://csaurl.org/circle-gsd](https://csaurl.org/circle-gsd).
+
+## Working Group Recurring Meetings
+
+The GSD Working Group meets every other Tuesday, from 9am-10am Pacific
+(12pm-1pm Eastern). To join, please see the "Virtual Meetings" section on the
+[working group calendar page](https://cloudsecurityalliance.org/research/working-groups/global-security-database).
+
+## GSD Quick Links
+
+This list is also accessible via the URL 
+[https://csaurl.org/gsd-quick-links](https://csaurl.org/gsd-quick-links)
+
+* About GSD
+  * Home Page: [https://globalsecuritydatabase.org](https://globalsecuritydatabase.org)
+  * Join the working group: [https://csaurl.org/gsd-landing-page](https://csaurl.org/gsd-landing-page)
+  * WG Meeting Agenda: [https://csaurl.org/gsd-agenda](https://csaurl.org/gsd-agenda)
+  * Press mentions: [https://globalsecuritydatabase.org/press](https://globalsecuritydatabase.org/press)
+* Communication Channels
+  * Circle Community (Forums): [https://csaurl.org/gsd-circle](https://csaurl.org/gsd-circle) 
+  * Mailing-list: [https://csaurl.org/gsd-mailing-list](https://csaurl.org/gsd-mailing-list)
+  * Slack: [https://csaurl.org/csa-public-slack](https://csaurl.org/csa-public-slack) #gsd-working-group
+* Interact with the data
+  * GitHub Repos: [https://github.com/cloudsecurityalliance/](https://github.com/cloudsecurityalliance/)
+  * Request a GSD: [https://requests.globalsecuritydatabase.org/](https://requests.globalsecuritydatabase.org/)
+  * Edit a GSD entry: [https://edit.globalsecuritydatabase.org/](https://edit.globalsecuritydatabase.org/)
+

--- a/website/consume/end-user.md
+++ b/website/consume/end-user.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Consuming GSD Data
+---
+
+TODO: add detail
+

--- a/website/consume/index.md
+++ b/website/consume/index.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Consuming GSD Data
+---
+
+Why do you want to consume GSD data?
+* I want to use data to [secure my systems]({% link consume/end-user.md %}).
+* I want to use data and [publish it]({% link consume/publisher.md %}).

--- a/website/consume/publisher.md
+++ b/website/consume/publisher.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Publishing GSD Data
+---
+
+TODO: add detail
+

--- a/website/contribute/data.md
+++ b/website/contribute/data.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Contributing Data to GSD
+---
+
+There are two ways to contribute or modify GSD data: 
+(1) via the website, and
+(2) via pull requests.
+For small updates, we recommend using the website.
+For larger bulk additions, we recommend a pull request (and a heads up).
+
+## Contributing via the Website
+
+TODO: add detail
+
+## Contributing via Pull Requests
+
+TODO: add detail

--- a/website/contribute/index.md
+++ b/website/contribute/index.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Contributing to GSD
+---
+
+How would you like to contribute to GSD?
+* I want to contribute or modify [data]({% link contribute/data.md %}).
+* I want to contribute or modify [tools]({% link contribute/tools.md %}).

--- a/website/contribute/tools.md
+++ b/website/contribute/tools.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Contributing Tools to GSD
+---
+
+GSD tools are publicly available on [GitHub](https://github.com/cloudsecurityalliance/gsd-tools).
+We welcome all contributions.
+
+## Helping with Issues
+
+TODO: add text
+
+## Contributing New Tools
+
+TODO: add text

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Global Security Database
+---
+
+Vulnerability data has never been more important than it is today, yet the data is not always machine readable, community updatable, or of an acceptable level of quality and completeness. Due to these problems we are seeing every ecosystem create their own bespoke vulnerability database. Vulnerability data has never been more important, or harder to use.
+
+The Global Security Database is addressing these issues in a way that builds community using the open source model. No one organization can be responsible for vulnerability data, it has to be a community effort with community ownership with a strong OpenSource license. The right way isn’t the GSD way, the right way is the open source way. Everyone from developers, companies, and ecosystems should work together to find solutions that work.
+
+The first step in this journey is to build the vulnerability community. If you are interested in working on data, policy, or tooling, please see the getting started guide and dive in!
+

--- a/website/press.md
+++ b/website/press.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Press
+permalink: /press/
+---
+
+TODO: this page lists GSD in the press


### PR DESCRIPTION
# Description

As discussed on the Jan 31, 2023 GSD call, I created an initial skeleton of a Jekyll-based static website for the GSD content. It is using the default minima scheme, which can be customized or replaced once we get content. The website is in a directory called `website` as discussed. The README.md has instructions on how to build and test locally, though this will be connected to Cloudflare pages.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The site has been tested with `bundle exec jekyll serve`. There are some warnings on my local system due to changes in sass and the minima theme using features that will be deprecated in a future version of sass. However, everything builds correctly.