### PR TITLE
Fix telemetry prompt causing gsd-api .devcontainer to hang on start

### DIFF
--- a/gsd-api/.config/.wrangler/metrics.json
+++ b/gsd-api/.config/.wrangler/metrics.json
@@ -1,0 +1,7 @@
+{
+	"permission": {
+		"enabled": false,
+		"date": "2022-07-04T00:00:00.000Z"
+	},
+	"deviceId": "telemetry-is-annoying"
+}

--- a/gsd-api/.devcontainer/devcontainer.json
+++ b/gsd-api/.devcontainer/devcontainer.json
@@ -8,6 +8,10 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
+	"mounts": [
+		"source=${localWorkspaceFolder}/.config/.wrangler,target=/home/node/.config/.wrangler,type=bind,consistency=cached"
+	],
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [8787],
 


### PR DESCRIPTION
Turns out wrangler decided to add telemetry, and it blocks the CLI from running until a human interacts with it, silently breaking the workflow.

This adds the json to tell it to knock it off, and mounts it in the appropriate place in the dev container.