### PR TITLE
Migrate to NVD 2.0 API

### DIFF
--- a/securitylist/src/tests/test_nvd.py
+++ b/securitylist/src/tests/test_nvd.py
@@ -26,9 +26,9 @@ def mocked_requests_get(*args, **kwargs):
         def raise_for_status(self):
             pass
 
-    if args[0] == 'https://services.nvd.nist.gov/rest/json/cve/1.0/CVE-1000-0001':
+    if args[0] == 'https://services.nvd.nist.gov/rest/json/cve/2.0/CVE-1000-0001':
         return MockResponse(200)
-    elif args[0] == 'https://services.nvd.nist.gov/rest/json/cve/1.0/CVE-1000-0002':
+    elif args[0] == 'https://services.nvd.nist.gov/rest/json/cve/2.0/CVE-1000-0002':
         return MockResponse(200)
 
     return MockResponse(404)

--- a/securitylist/src/update_nvd.py
+++ b/securitylist/src/update_nvd.py
@@ -23,7 +23,7 @@ def main():
     print("Getting %d IDs" % nvd.total)
 
     for i in nvd:
-        the_id = i['cve']['CVE_data_meta']['ID']
+        the_id = i['cve']['id']
         # We need to put these in the NVD namespace
         c = securitylist.CVE(the_id)
         c.add_data('nvd.nist.gov', i)


### PR DESCRIPTION
# Description

As noted from #224 , we need to upgrade to the NVD 2.0 API. There is a significant redesign in the way the API works, but our stuff should mostly keep working. Tested it locally and it seemed to not make major mistakes. 
cc @joshbressers please test it because I know you might have more insights on this from the v1 API work.

Fixes #224 

## Type of change

Changes NVD Data Source from v1 of their API to v2.

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Tested locally against the copy of gsd-database.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
